### PR TITLE
Use leopard fork to recover parity data without re-encoding

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "leopard/leopard"]
 	path = leopard/leopard
-	url = https://github.com/catid/leopard.git
+	url = https://github.com/Liamsi/leopard.git

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ test: install-cleo
 # only necessary if you need to re-generate the c-go bindings
 # Note: deletes all previously generated c-go bindings and
 # any build
-re-generate: clean
+re-generate: clean_generated
 	c-for-go --ccincl leopard.yml
 
 # init leopard submodule and build C library
@@ -20,10 +20,12 @@ install-cleo: build-cleo
 	cp leopard/build/liblibleopard.a $(INSTALL_DIR)/
 
 # clean generated files and build artifacts
-clean:
+clean_generated:
 	rm -f leopard/cgo_helpers.go leopard/cgo_helpers.h leopard/cgo_helpers.c
 	rm -f leopard/const.go leopard/doc.go leopard/types.go
 	rm -f leopard/leopard.go
+
+clean_build:
 	rm -rf leopard/build
 
 uninstall-cleo:

--- a/wrapper.go
+++ b/wrapper.go
@@ -144,7 +144,9 @@ func Recover(orig, recovery [][]byte) (decodeWork [][]byte, err error) {
 
 	toGoByte(decodeWorkPtr, decodeWork, int(bufferBytes))
 	// leopard only recovers missing original chunks:
-	decodeWork = decodeWork[:len(decodeWork)/2]
+	// decodeWork = decodeWork[:len(decodeWork)/2]
+	// modified fork at:
+	// https://github.com/Liamsi/leopard/tree/recover_parity_chunks_too
 	return
 }
 

--- a/wrapper.go
+++ b/wrapper.go
@@ -157,31 +157,21 @@ func Recover(orig, recovery [][]byte) (decodeWork [][]byte, err error) {
 // On success, it returns (orig || recovery) with all data recovered.
 // Missing data (either original or recovery) has to be nil when passed in.
 func Decode(orig, recovery [][]byte) (decoded [][]byte, err error) {
-	decodedOrig, err := Recover(orig, recovery)
+	decoded, err = Recover(orig, recovery)
 	if err != nil {
 		return nil, err
 	}
 	for i := 0; i < len(orig); i++ {
 		if orig[i] != nil {
-			decodedOrig[i] = orig[i]
+			decoded[i] = orig[i]
 		}
 	}
-	lostRecoveryShares := false
 	for i := 0; i < len(recovery); i++ {
-		if recovery[i] == nil {
-			lostRecoveryShares = true
-			break
+		if recovery[i] != nil {
+			decoded[i+len(orig)] = recovery[i]
 		}
 	}
-	if lostRecoveryShares {
-		encoded, err := Encode(decodedOrig)
-		if err != nil {
-			return nil, err
-		}
-		decoded = append(decodedOrig, encoded...)
-	} else {
-		decoded = append(decodedOrig, recovery...)
-	}
+
 	return
 }
 


### PR DESCRIPTION
Modified the C++ library to also recover the parity data when decoding (for ff8 and ff16).

This PR changes the submodule to use the fork and updates the `Decode` method accordingly.